### PR TITLE
Add CMakePresets.json and vcpkg.json for easier project setup

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "vendor/vcpkg"]
+	path = vendor/vcpkg
+	url = https://github.com/microsoft/vcpkg

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -15,7 +15,7 @@
       "binaryDir": "${sourceDir}/build/${presetName}",
       "cacheVariables": {
         "CMAKE_TOOLCHAIN_FILE": {
-          "value": "vendor/vcpkg/scripts/buildsystems/vcpkg.cmake",
+          "value": "${sourceDir}/vendor/vcpkg/scripts/buildsystems/vcpkg.cmake",
           "type": "FILEPATH"
         }
       }
@@ -37,6 +37,16 @@
       "cacheVariables": {
         "CMAKE_BUILD_TYPE": "RelWithDebInfo"
       }
+    }
+  ],
+  "buildPresets": [
+    {
+      "name": "debug",
+      "configurePreset": "debug"
+    },
+    {
+      "name": "release",
+      "configurePreset": "release"
     }
   ]
 }

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -1,0 +1,42 @@
+{
+  "version": 3,
+  "cmakeMinimumRequired": {
+    "major": 3,
+    "minor": 14,
+    "patch": 0
+  },
+  "configurePresets": [
+    {
+      "hidden": true,
+      "name": "base",
+      "displayName": "Base Config",
+      "description": "Base configuration using Ninja and vcpkg",
+      "generator": "Ninja",
+      "binaryDir": "${sourceDir}/build/${presetName}",
+      "cacheVariables": {
+        "CMAKE_TOOLCHAIN_FILE": {
+          "value": "vendor/vcpkg/scripts/buildsystems/vcpkg.cmake",
+          "type": "FILEPATH"
+        }
+      }
+    },
+    {
+      "name": "debug",
+      "inherits": "base",
+      "displayName": "Debug",
+      "description": "Build debug",
+      "cacheVariables": {
+        "CMAKE_BUILD_TYPE": "Debug"
+      }
+    },
+    {
+      "name": "release",
+      "inherits": "base",
+      "displayName": "Release",
+      "description": "Build release",
+      "cacheVariables": {
+        "CMAKE_BUILD_TYPE": "RelWithDebInfo"
+      }
+    }
+  ]
+}

--- a/README.md
+++ b/README.md
@@ -6,18 +6,16 @@ foundation. Then, after completing the tutorial, I will modify the code with the
 aim to produce a basic 3D renderer. The scope of the 3D renderer will be decided
 at a later point.
 
-# Requirements
+# External Dependencies
 
-This project has only been tested on Linux and Windows, but should work on other
-platforms. Vcpkg is recommended for managing dependencies.
+This project uses vcpkg to pull in most dependencies. However, the following must
+still be installed manually:
 
-| Dependency                                 | Version Used in Project |
-|--------------------------------------------|-------------------------|
-| A C++ compiler with C++20 support          | `13.0.1 (clang)`        |
-| [CMake](https://cmake.org/download/)       | `3.23.0`                |
-| [Vulkan SDK](https://vulkan.lunarg.com/)   | `1.3.211`               |
-| [GLFW](https://www.glfw.org/)              | `3.3.7 (glfw-x11)`      |
-| [GLM](https://github.com/g-truc/glm)       | `0.9.9.8`               |
+| Dependency                               | Version Used in Project |
+|------------------------------------------|-------------------------|
+| A C++ compiler with C++20 support        | `13.0.1 (clang)`        |
+| [CMake](https://cmake.org/download/)     | `3.23.0`                |
+| [Vulkan SDK](https://vulkan.lunarg.com/) | `1.3.211`               |
 
 # Progress Preview
 

--- a/vcpkg.json
+++ b/vcpkg.json
@@ -1,0 +1,8 @@
+{
+  "name": "vulkan-sandbox",
+  "version-string": "0.1.0",
+  "dependencies": [
+    "glfw3",
+    "glm"
+  ]
+}


### PR DESCRIPTION
Add vcpkg as git submodule.
Add vcpkg.json to automatically handle pulling dependencies.
Remove dependencies handled by vcpkg from README.
Add CMakePresets.json to handle vcpkg integration.